### PR TITLE
Adds link to structslop

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A curated list of [Go](https://golang.org/) code formatters.
 * [goreturns](https://github.com/sqs/goreturns) -- fills in return statements with zero values to match the func return types.
 * [keyify](https://github.com/dominikh/go-tools/tree/master/cmd/keyify) -- turns unkeyed struct literals into keyed ones.
 * [unconvert](https://github.com/mdempsky/unconvert) -- removes unnecessary type conversions.
+* [structslop](https://github.com/orijtech/structslop) -- checks struct can be re-arranged fields to get optimal struct size (can reduce memory use in large collections of struct instances) -- [Medium article here](https://medium.com/orijtech-developers/efficient-struct-packing-guided-pass-for-go-92255872ec72).
 
 ## Imports formatters
 


### PR DESCRIPTION
I'm not associated with Orijtech or the project, but I read the write-up in Medium a week or two ago.  This is *technically* a code formatter, because all it does is re-arrange the order of struct fields.  It has a measurable impact on the code produced by the current compiler, because careful arrangement of fields allows the compiler to pack field values together more efficiently, which can in turn result in memory use savings -- especially in applications which generate large, in-memory collections of structs.

The article (linked) describes the process and results, including measurements of savings.